### PR TITLE
Titulo REFERENCIAS

### DIFF
--- a/Templates/URI-TCC/template-config/uri-abntex2.cls
+++ b/Templates/URI-TCC/template-config/uri-abntex2.cls
@@ -262,7 +262,7 @@
     \renewcommand{\subsubsectionautorefname}{Subsubse\c{c}\~ao}
     \renewcommand{\paragraphautorefname}{Subse\c{c}\~ao}
 % Ajusta nome da Referências para REFERÊNCIAS
-    \renewcommand{\bibname}{REFERÊNCIAS}
+    \renewcommand{\bibname}{REFER{\^E}NCIAS}
 }
 
 


### PR DESCRIPTION
Ajustado o titulo das referencias. O titulo apresentava um erro de exibição do caractere 'e' com acentuação no arquivo PDF resultado da compilação.